### PR TITLE
Fix to use $input_id to repopulate data

### DIFF
--- a/tabular/tabular.class.php
+++ b/tabular/tabular.class.php
@@ -89,9 +89,9 @@ class PerchFieldType_tabular extends PerchAPI_FieldType
          * used to pre-populate the table in the admin panel.
          */
 
-        if (isset($details[$id]) && is_array($details[$id])) {
-            if (isset($details[$id][self::DATA_KEY]) && is_array($details[$id][self::DATA_KEY])) {
-                $data = $details[$id][self::DATA_KEY];
+        if (isset($details[$input_id]) && is_array($details[$input_id])) {
+            if (isset($details[$input_id][self::DATA_KEY]) && is_array($details[$input_id][self::DATA_KEY])) {
+                $data = $details[$input_id][self::DATA_KEY];
             }
         }
 


### PR DESCRIPTION
This was using `$this->Tag->id()` instead of `$this->Tag->input_id()` to read in the data. This happened to work pre-Repeaters, but wasn't designed to be used that way.

Switching to use `$this->Tag->input_id()` should work correctly both pre- and post- Perch 2.3 and should even work within Repeaters.
